### PR TITLE
newpipe.sh: remove workaround environment variables

### DIFF
--- a/newpipe.sh
+++ b/newpipe.sh
@@ -1,5 +1,3 @@
 #!/bin/sh
 export JAVA_HOME=/app/share/java_home
-export LD_LIBRARY_PATH=/app/lib/art
-ln -s $XDG_CACHE_HOME ~/.cache
 exec android-translation-layer --gapplication-app-id=net.newpipe.NewPipe /app/share/NewPipe.apk $@


### PR DESCRIPTION
Things have been fixed properly in Android Translation Layer by now