### PR TITLE
Comply with "NewPipe" trademark policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,10 @@
+# Unofficial Flatpak distribution metadata for NewPipe
+
+These metadata files are what power the [unofficial NewPipe Flatpak package on Flathub](https://flathub.org/apps/net.newpipe.NewPipe).
+
+The build step pretty much only glues Android Translation Layer and the latest NewPipe release together. Thus, the real magic happens here:
+
+* https://gitlab.com/android_translation_layer/android_translation_layer/
+* https://github.com/TeamNewPipe/NewPipe
+
+This distribution is neither affiliated with nor endorsed by TeamNewPipe.

--- a/net.newpipe.NewPipe.desktop
+++ b/net.newpipe.NewPipe.desktop
@@ -2,6 +2,6 @@
 Type=Application
 Name=NewPipe
 Exec=newpipe.sh --uri %u
-Comment=Lightweight YouTube frontend 
+Comment=Lightweight YouTube frontend (unofficial port)
 X-Purism-FormFactor=Workstation;Mobile;
 Icon=net.newpipe.NewPipe

--- a/net.newpipe.NewPipe.metainfo.xml
+++ b/net.newpipe.NewPipe.metainfo.xml
@@ -1,17 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
 <component type="desktop-application">
   <id>net.newpipe.NewPipe</id>
-  <name>NewPipe</name>
+  <name>NewPipe (unofficial port)</name>
   <summary>Free and lightweight YouTube frontend for Android</summary>
   <project_license>GPL-3.0-or-later</project_license>
   <metadata_license>CC0-1.0</metadata_license>
-  <url type="vcs-browser">https://github.com/TeamNewPipe/NewPipe</url>
-  <url type="homepage">https://newpipe.net/</url>
+  <url type="vcs-browser">https://github.com/flathub/net.newpipe.NewPipe</url>
   <url type="bugtracker">https://gitlab.com/android_translation_layer/android_translation_layer/-/issues</url>
   <url type="donation">https://newpipe.net/donate/</url>
   <url type="translate">https://hosted.weblate.org/engage/newpipe/</url>
   <description>
-    <p><em>NOTE:</em> This is an unofficial and experimental Flatpak build based on Android Translation Layer. Please report bugs to the ATL bug tracker instead of the NewPipe bug tracker https://gitlab.com/android_translation_layer/android_translation_layer/-/issues.</p>
+	  <p><em>NOTE:</em> This is an unofficial and experimental Flatpak build based on Android Translation Layer. It is <em>not</em> assembled by TeamNewPipe, and it is neither affiliated with nor endorsed by TeamNewPipe. Please report bugs to the ATL bug tracker instead of the NewPipe bug tracker: https://gitlab.com/android_translation_layer/android_translation_layer/-/issues.</p>
     <p>NewPipe is a privacy-preserving YouTube frontend. NewPipe does not use any Google framework libraries, or the YouTube API. It only parses the website in order to gain the information it needs. Therefore this app can be used on devices without Google Services installed. Also, you don't need a YouTube account to use NewPipe, and it's FLOSS.</p>
     <p>NewPipe currently supports these services:</p>
     <ul>
@@ -84,7 +83,7 @@
     <content_attribute id="money-advertising">moderate</content_attribute>
   </content_rating>
   <developer id="net.newpipe">
-    <name>Developer of the NewPipe app</name>
+    <name>Packaged by Android Translation Layer</name>
   </developer>
   <releases>
     <release version="0.27.6" date="2025-02-05">

--- a/net.newpipe.NewPipe.metainfo.xml
+++ b/net.newpipe.NewPipe.metainfo.xml
@@ -6,6 +6,7 @@
   <project_license>GPL-3.0-or-later</project_license>
   <metadata_license>CC0-1.0</metadata_license>
   <url type="vcs-browser">https://github.com/flathub/net.newpipe.NewPipe</url>
+  <url type="homepage">https://github.com/flathub/net.newpipe.NewPipe/blob/master/README.md</url>
   <url type="bugtracker">https://gitlab.com/android_translation_layer/android_translation_layer/-/issues</url>
   <url type="donation">https://newpipe.net/donate/</url>
   <url type="translate">https://hosted.weblate.org/engage/newpipe/</url>


### PR DESCRIPTION
Hello everyone,

we would like to politely notify you that the term "NewPipe" has been [filed as a trademark with EUIPO](https://euipo.europa.eu/eSearch/#details/trademarks/019104121) by NewPipe e.V., and that the mark is about to become active (i.e. registered). This flatpak port project is using our mark as the package carries "NewPipe" as its user-facing name.

Per [our trademark policy](https://newpipe-ev.de/policy/trademark.html), unofficial builds of NewPipe like this project are permitted to use our mark, but we have some requests concerning clarity about the unofficial status of the project that we formalized in this policy.

I am providing you with this patch to make the flatpak metadata compliant with our policy by more visibly declaring the project as unofficial. Specifically:

* Title in storefront (not in .desktop) changed to "NewPipe (unofficial port)"
* Declare not being affiliated with TeamNewPipe.
* Link to this repository as VCS instead of NewPipe's repository.
* To complement the above, add a README that points to both projects that this metadata glues together (NewPipe + Android Translation Layer).

Thank you for your efforts in maintaining this build!

Fynn for the NewPipe e.V. board