### PR TITLE
Add StartupNotify=true to desktop file

### DIFF
--- a/net.newpipe.NewPipe.desktop
+++ b/net.newpipe.NewPipe.desktop
@@ -4,4 +4,5 @@ Name=NewPipe
 Exec=newpipe.sh --uri %u
 Comment=Lightweight YouTube frontend (unofficial port)
 X-Purism-FormFactor=Workstation;Mobile;
+StartupNotify=true
 Icon=net.newpipe.NewPipe


### PR DESCRIPTION
With the MR giving processes with a pid more time to start in Phosh[1], setting StartupNotify=true allows the shell to display a splash that lasts until NewPipe actually starts up even on slow devices like the original PinePhone. As such, let's set it here to improve UX.

 [1]: https://gitlab.gnome.org/World/Phosh/phosh/-/merge_requests/1915